### PR TITLE
Update to cjl script to support IBM SDK for Linux, Java Technology Edition, Version 6 

### DIFF
--- a/clj
+++ b/clj
@@ -105,7 +105,13 @@ if [ -z "$JAVA" ]; then
     if $cygwin; then
       JAVA_HOME=`cygpath "$JAVA_HOME"`
     fi
-    JAVA="$JAVA_HOME/bin/java"
+
+    if [ -e "$JAVA_HOME/jre/bin/java" ]; then
+      JAVA="$JAVA_HOME/jre/bin/java"
+    else
+      JAVA="$JAVA_HOME/bin/java"
+    fi 
+
   else
     # last ditch -- look for java on the path
     JAVA=`type -P java`


### PR DESCRIPTION
Hi,

Updated to support using IBM SDK for Linux, Java Technology Edition, Version 6.  When using this version of Java from IBM, there isn't a java with $JAVA_HOME/bin.

Thanks,
skk
